### PR TITLE
GitHub issue fixes

### DIFF
--- a/Source/Microsoft.Teams.Apps.DLLookup/ClientApp/src/App.scss
+++ b/Source/Microsoft.Teams.Apps.DLLookup/ClientApp/src/App.scss
@@ -7,7 +7,6 @@
 */
 .default-container {
     height: 100vh !important;
-    /*        background-color: #F3F2F1;*/
     background-color: #FFFFFF;
 
     .configContainer {

--- a/Source/Microsoft.Teams.Apps.DLLookup/ClientApp/src/App.scss
+++ b/Source/Microsoft.Teams.Apps.DLLookup/ClientApp/src/App.scss
@@ -7,8 +7,9 @@
 */
 .default-container {
     height: 100vh !important;
-/*        background-color: #F3F2F1;*/
-        background-color: #FFFFFF;
+    /*        background-color: #F3F2F1;*/
+    background-color: #FFFFFF;
+
     .configContainer {
         background-color: #fff;
     }
@@ -103,6 +104,10 @@
 .darkContainer {
     background-color: #201f1f;
     height: 100vh !important;
+
+    .app-container {
+        background: #292929 !important;
+    }
 
     .configContainer {
         background-color: #2d2c2c;
@@ -341,6 +346,7 @@
     width: 100%;
     overflow: hidden;
     height: 100%;
+
     .primaryBtn {
         min-width: 9.6rem;
         height: 3.2rem;
@@ -455,8 +461,8 @@
     }
 }
 
-.textAlignCenter{
-    text-align:center;
+.textAlignCenter {
+    text-align: center;
 }
 
 /* width */
@@ -481,5 +487,12 @@
 ::-webkit-scrollbar-thumb:hover {
     ::-webkit-scrollbar {
         width: 1rem;
+    }
+}
+
+.highContrastContainer {
+
+    .app-container {
+        background: #000000 !important;
     }
 }

--- a/Source/Microsoft.Teams.Apps.DLLookup/ClientApp/src/apis/api-list.ts
+++ b/Source/Microsoft.Teams.Apps.DLLookup/ClientApp/src/apis/api-list.ts
@@ -77,7 +77,7 @@ export const createUserPageSizeChoice = async (payload: {}): Promise<AxiosRespon
 }
 
 export const getAuthenticationMetadata = async (windowLocationOriginDomain: string, loginHint: string): Promise<AxiosResponse<string>> => {
-    const payload = { windowLocationOriginDomain: encodeURIComponent(windowLocationOriginDomain), loginhint: loginHint };
+    const payload = { windowLocationOriginDomain: windowLocationOriginDomain, loginhint: loginHint };
     let url = `${baseAxiosUrl}/authenticationMetadata/GetAuthenticationUrlWithConfiguration`;
     return await axios.post(url, payload);
 }

--- a/Source/Microsoft.Teams.Apps.DLLookup/ClientApp/src/apis/api-list.ts
+++ b/Source/Microsoft.Teams.Apps.DLLookup/ClientApp/src/apis/api-list.ts
@@ -17,7 +17,7 @@ export const getFavoriteDistributionLists = async (): Promise<AxiosResponse<IDis
 }
 
 export const getADDistributionLists = async (query: string): Promise<AxiosResponse<IADDistributionList[]>> => {
-    let url = baseAxiosUrl + "/distributionlists/getDistributionList?query=" + query;
+    let url = baseAxiosUrl + "/distributionlists/getDistributionList?query=" + encodeURIComponent(query);
     return await axios.get(url);
 }
 
@@ -77,8 +77,9 @@ export const createUserPageSizeChoice = async (payload: {}): Promise<AxiosRespon
 }
 
 export const getAuthenticationMetadata = async (windowLocationOriginDomain: string, loginHint: string): Promise<AxiosResponse<string>> => {
-    let url = `${baseAxiosUrl}/authenticationMetadata/GetAuthenticationUrlWithConfiguration?windowLocationOriginDomain=${windowLocationOriginDomain}&loginhint=${loginHint}`;
-    return await axios.get(url, undefined, false);
+    const payload = { windowLocationOriginDomain: encodeURIComponent(windowLocationOriginDomain), loginhint: loginHint };
+    let url = `${baseAxiosUrl}/authenticationMetadata/GetAuthenticationUrlWithConfiguration`;
+    return await axios.post(url, payload);
 }
 
 export const getClientId = async (): Promise<AxiosResponse<string>> => {

--- a/Source/Microsoft.Teams.Apps.DLLookup/ClientApp/src/components/distribution-lists/distribution-lists.scss
+++ b/Source/Microsoft.Teams.Apps.DLLookup/ClientApp/src/components/distribution-lists/distribution-lists.scss
@@ -67,16 +67,6 @@
     color: #484644 !important;
 }
 
-.search-box input {
-    background-color: #FFFFFF !important;
-    border-radius: 3px;
-    color: #484644 !important;
-}
-
-.search-box input:-ms-input-placeholder {
-    color: #484644 !important;
-}
-
 .div-style {
     width: 165px !important;
 }
@@ -147,10 +137,6 @@
     background: #F3F2F1 !important;
 }
 
-.text-style {
-    color: #252423 !important;
-}
-
 .actions-style {
     padding-left: 4.5em !important;
 }
@@ -162,4 +148,105 @@
 .info-icon {
     padding-left: 1%;
     font-size: small;
+}
+
+.default-container {
+
+    .search-box input {
+        background-color: #FFFFFF !important;
+        border-radius: 3px;
+        color: #484644 !important;
+    }
+
+    .search-box input:-ms-input-placeholder {
+        color: #484644 !important;
+    }
+
+    .text-style {
+        color: #252423 !important;
+    }
+}
+
+.darkContainer {
+
+    .main-component {
+        background: #292929 !important;
+
+        .form-content-container {
+            .textstyle {
+                color: rgb(200, 198, 196) !important;
+            }
+        }
+
+        .textstyle {
+            color: rgb(200, 198, 196) !important;
+        }
+    }
+
+    .header {
+        border-bottom: 1px solid #292929 !important;
+        background-color: rgb(32, 31, 31) !important;
+
+        .dark-theme {
+            color: rgb(200, 198, 196) !important;
+        }
+    }
+
+    .border-none {
+        border-bottom: 1px solid #292929 !important;
+        background-color: rgb(32, 31, 31) !important;
+        color: rgb(200, 198, 196) !important;
+    }
+
+    .header {
+        color: #FFFFFF !important;
+    }
+
+    .main-component {
+        .footer-container div {
+            background: #292929 !important;
+        }
+    }
+}
+
+.highContrastContainer {
+
+    .main-component {
+        background: #0f0f0f !important;
+
+        .form-content-container {
+            .textstyle {
+                color: rgb(200, 198, 196) !important;
+            }
+        }
+
+        .textstyle {
+            color: rgb(200, 198, 196) !important;
+        }
+    }
+
+    .header {
+        border-bottom: 1px solid #292929 !important;
+        background-color: rgb(32, 31, 31) !important;
+
+        .dark-theme {
+            color: rgb(200, 198, 196) !important;
+        }
+    }
+
+    .border-none {
+        border-bottom: 1px solid #292929 !important;
+        background-color: rgb(32, 31, 31) !important;
+        color: rgb(200, 198, 196) !important;
+    }
+
+    .header {
+        color: #FFFFFF !important;
+    }
+
+    .main-component {
+        .footer-container div {
+            background: #0f0f0f !important;
+        }
+    }
 }

--- a/Source/Microsoft.Teams.Apps.DLLookup/Controllers/AuthenticationMetadataController.cs
+++ b/Source/Microsoft.Teams.Apps.DLLookup/Controllers/AuthenticationMetadataController.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Teams.Apps.DLLookup.Controllers
     using System.Web;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Configuration;
+    using Microsoft.Teams.Apps.DLLookup.Models;
 
     /// <summary>
     /// Controller for the authentication sign in data.
@@ -35,24 +36,21 @@ namespace Microsoft.Teams.Apps.DLLookup.Controllers
         /// <summary>
         /// Get authentication URL with configuration options.
         /// </summary>
-        /// <param name="windowLocationOriginDomain">Window location origin domain.</param>
-        /// <param name="loginHint">User Principal name value.</param>
+        /// <param name="authenticationInfo">Instance of athentication info model to get window origin and login hint details.</param>
         /// <returns>Consent URL.</returns>
-        [HttpGet("GetAuthenticationUrlWithConfiguration")]
-        public string GetAuthenticationUrlWithConfiguration(
-            [FromQuery]string windowLocationOriginDomain,
-            [FromQuery]string loginHint)
+        [HttpPost("GetAuthenticationUrlWithConfiguration")]
+        public string GetAuthenticationUrlWithConfiguration([FromBody] AuthenticationInfo authenticationInfo)
         {
             Dictionary<string, string> authDictionary = new Dictionary<string, string>
             {
-                ["redirect_uri"] = $"https://{windowLocationOriginDomain}/signin-simple-end",
+                ["redirect_uri"] = $"https://{authenticationInfo.WindowLocationOriginDomain}/signin-simple-end",
                 ["client_id"] = this.clientId,
                 ["response_type"] = "id_token",
                 ["response_mode"] = "fragment",
                 ["scope"] = this.graphScope,
                 ["nonce"] = Guid.NewGuid().ToString(),
                 ["state"] = Guid.NewGuid().ToString(),
-                ["login_hint"] = loginHint,
+                ["login_hint"] = authenticationInfo.LoginHint,
             };
             List<string> authList = authDictionary
                 .Select(p => $"{p.Key}={HttpUtility.UrlEncode(p.Value)}")

--- a/Source/Microsoft.Teams.Apps.DLLookup/Helpers/GraphUtilityHelper.cs
+++ b/Source/Microsoft.Teams.Apps.DLLookup/Helpers/GraphUtilityHelper.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Teams.Apps.DLLookup.Helpers
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Net;
     using System.Net.Http.Headers;
     using System.Threading.Tasks;
     using Microsoft.Extensions.Logging;
@@ -70,11 +69,10 @@ namespace Microsoft.Teams.Apps.DLLookup.Helpers
         {
             try
             {
-                query = Uri.EscapeDataString(query);
                 var response = await this.graphClient
                 .Groups
                 .Request()
-                .Filter($"startswith(displayName, '{query}')")
+                .Filter($"startswith(displayName, '{Uri.EscapeDataString(query)}')")
                 .GetAsync();
 
                 var distributionList = response.

--- a/Source/Microsoft.Teams.Apps.DLLookup/Helpers/GraphUtilityHelper.cs
+++ b/Source/Microsoft.Teams.Apps.DLLookup/Helpers/GraphUtilityHelper.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Teams.Apps.DLLookup.Helpers
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Net;
     using System.Net.Http.Headers;
     using System.Threading.Tasks;
     using Microsoft.Extensions.Logging;
@@ -69,6 +70,7 @@ namespace Microsoft.Teams.Apps.DLLookup.Helpers
         {
             try
             {
+                query = Uri.EscapeDataString(query);
                 var response = await this.graphClient
                 .Groups
                 .Request()

--- a/Source/Microsoft.Teams.Apps.DLLookup/Models/AuthenticationInfo.cs
+++ b/Source/Microsoft.Teams.Apps.DLLookup/Models/AuthenticationInfo.cs
@@ -1,0 +1,22 @@
+﻿// <copyright file="AuthenticationInfo.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+
+namespace Microsoft.Teams.Apps.DLLookup.Models
+{
+    /// <summary>
+    /// AuthenticationInfo model represents information required to get athentication Uri.
+    /// </summary>
+    public class AuthenticationInfo
+    {
+        /// <summary>
+        /// Gets or sets window location domain origin.
+        /// </summary>
+        public string WindowLocationOriginDomain { get; set; }
+
+        /// <summary>
+        /// Gets or sets login hint details.
+        /// </summary>
+        public string LoginHint { get; set; }
+    }
+}


### PR DESCRIPTION
**Issue 1**:
Groups which name starts with # not visible in the app
https://github.com/OfficeDev/microsoft-teams-apps-contactgrouplookup/issues/22 

When the group name starts with the symbol # the group is not visible in the tool. Moreover if you try searching for that group by name the app shows the blue spinning wheel and stays there.

Fix
Added URL encoding

Testing
Verified groups starts with # and other special characters shown in search

**Issue 2**:
poorly readable in dark mode
https://github.com/OfficeDev/microsoft-teams-apps-contactgrouplookup/issues/15 

If you are using the dark mode in Teams, the group name is poorly readable

Fix
Added styling for both dark and high contrast mode

Testing
Verified both dark and high contrast modes